### PR TITLE
Make banner API use specific dev namespaces [WIP]

### DIFF
--- a/_infra/helm/banner-api/Chart.yaml
+++ b/_infra/helm/banner-api/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.2.0
 
-appVersion: 1.1.6
+appVersion: 1.1.7

--- a/_infra/helm/banner-api/templates/deployments.yaml
+++ b/_infra/helm/banner-api/templates/deployments.yaml
@@ -54,5 +54,7 @@ spec:
             value: {{ .Values.gcp.project }}
           - name: SERVER_PORT
             value: "{{ .Values.container.port }}"
+          - name: GOOGLE_DATASTORE_NAMESPACE
+            value: {{ .Values.gcp.datastore.namespace }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/_infra/helm/banner-api/values.yaml
+++ b/_infra/helm/banner-api/values.yaml
@@ -4,6 +4,8 @@ publicIP: false
 
 gcp:
   project: ras-rm-sandbox
+  datastore:
+    namespace: "crockerm"
 
 image:
   devRepo: eu.gcr.io/ons-rasrmbs-management

--- a/_infra/helm/banner-api/values.yaml
+++ b/_infra/helm/banner-api/values.yaml
@@ -5,7 +5,7 @@ publicIP: false
 gcp:
   project: ras-rm-sandbox
   datastore:
-    namespace: "crockerm"
+    namespace: dev
 
 image:
   devRepo: eu.gcr.io/ons-rasrmbs-management

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=8000
+spring.cloud.gcp.datastore.namespace=${GOOGLE_DATASTORE_NAMESPACE}


### PR DESCRIPTION
# What and why?
Banner API works fine in preprod/prod, but in dev it assigns one banner to every one of our environments. This uses datastore's namespace attribute to pick between them

# How to test?
* Deploy to your environment
* Set a banner
* Go to GCP > Datastore and check that there's an entry for the crockerm namespace (we'll need to modify our pipelines to make this a different namespace each)

# Trello
https://trello.com/c/PjwS43oN/472-s30-alert-banner-management-only-set-banner-for-your-own-dev-environment