### PR TITLE
Update GCP Spring starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.1</version>
+            <version>2.14.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.9</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
+            <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-data-datastore</artifactId>
-            <version>1.2.8.RELEASE</version>
+            <version>4.8.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,18 @@
         </dependency>
 
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.11</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-logging-logback</artifactId>
+            <version>0.130.26-alpha</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>
@@ -61,19 +67,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.15.1</version>
         </dependency>
 
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>7.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.4.11</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,11 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.2</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.source>17</java.source>
         <java.target>17</java.target>
-        <springboot.version>2.6.6</springboot.version>
         <spring-cloud-gcp.version>4.8.1</spring-cloud-gcp.version>
 		<spring-cloud.version>2022.0.4</spring-cloud.version>
     </properties>
@@ -37,13 +36,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.0.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
     <groupId>uk.gov.onsdigital</groupId>
     <artifactId>banner-api</artifactId>
     <version>unversioned</version>
@@ -13,9 +19,15 @@
         <java.source>17</java.source>
         <java.target>17</java.target>
         <springboot.version>2.6.6</springboot.version>
+        <spring-cloud-gcp.version>4.8.1</spring-cloud-gcp.version>
+		<spring-cloud.version>2022.0.4</spring-cloud.version>
     </properties>
 
     <dependencies>
+        <dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>spring-cloud-gcp-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-data-datastore</artifactId>
@@ -26,12 +38,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${springboot.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>5.3.20</version>
         </dependency>
 
         <dependency>
@@ -80,6 +86,24 @@
         </dependency>
 
     </dependencies>
+    <dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>spring-cloud-gcp-dependencies</artifactId>
+				<version>${spring-cloud-gcp.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
     <build>
         <finalName>banner-api</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${springboot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>uk.gov.onsdigital.banner.Application</mainClass>

--- a/src/main/java/uk/gov/onsdigital/banner/Application.java
+++ b/src/main/java/uk/gov/onsdigital/banner/Application.java
@@ -2,8 +2,10 @@ package uk.gov.onsdigital.banner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.service" })
 public class Application {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/gov/onsdigital/banner/Application.java
+++ b/src/main/java/uk/gov/onsdigital/banner/Application.java
@@ -2,10 +2,8 @@ package uk.gov.onsdigital.banner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.service" })
 public class Application {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/gov/onsdigital/banner/controller/BannerController.java
+++ b/src/main/java/uk/gov/onsdigital/banner/controller/BannerController.java
@@ -16,8 +16,6 @@ import uk.gov.onsdigital.banner.service.BannerService;
 
 import java.util.NoSuchElementException;
 
-import static net.logstash.logback.argument.StructuredArguments.kv;
-
 @RestController
 @RequestMapping("/banner")
 public class BannerController {
@@ -26,13 +24,13 @@ public class BannerController {
 
   @Autowired
   private BannerService bannerService;
-  
+
   @GetMapping("")
   public ResponseEntity<BannerModel> getBanner() {
     try {
       BannerModel banner = bannerService.getBanner("active");
       return ResponseEntity.ok().body(banner);
-    } catch(NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
       LOGGER.info("No banner currently active");
       return ResponseEntity.notFound().build();
     }
@@ -48,7 +46,7 @@ public class BannerController {
 
   @DeleteMapping("")
   public ResponseEntity<BannerModel> removeBanner() {
-      bannerService.removeBanner("active");
-      return ResponseEntity.noContent().build();
+    bannerService.removeBanner("active");
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/uk/gov/onsdigital/banner/controller/InfoController.java
+++ b/src/main/java/uk/gov/onsdigital/banner/controller/InfoController.java
@@ -1,22 +1,14 @@
 package uk.gov.onsdigital.banner.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import uk.gov.onsdigital.banner.model.BannerModel;
-import uk.gov.onsdigital.banner.service.BannerService;
-
-import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/info")
 public class InfoController {
-  
+
   @GetMapping("")
   public ResponseEntity<Void> getInfo() {
-      return ResponseEntity.ok().build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/uk/gov/onsdigital/banner/model/BannerModel.java
+++ b/src/main/java/uk/gov/onsdigital/banner/model/BannerModel.java
@@ -4,9 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Unindexed;
+import com.google.cloud.spring.data.datastore.core.mapping.Entity;
+import com.google.cloud.spring.data.datastore.core.mapping.Field;
+import com.google.cloud.spring.data.datastore.core.mapping.Unindexed;
 import org.springframework.data.annotation.Id;
 
 @Data

--- a/src/main/java/uk/gov/onsdigital/banner/model/TemplateModel.java
+++ b/src/main/java/uk/gov/onsdigital/banner/model/TemplateModel.java
@@ -1,8 +1,8 @@
 package uk.gov.onsdigital.banner.model;
 
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Unindexed;
+import com.google.cloud.spring.data.datastore.core.mapping.Entity;
+import com.google.cloud.spring.data.datastore.core.mapping.Field;
+import com.google.cloud.spring.data.datastore.core.mapping.Unindexed;
 import org.springframework.data.annotation.Id;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity(name = "BannerTemplate")
 public class TemplateModel {
-  
+
   @Id
   @Field(name = "id")
   private Long id;

--- a/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
@@ -1,10 +1,7 @@
 package uk.gov.onsdigital.banner.repository;
 
-import org.springframework.stereotype.Repository;
-
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.BannerModel;
 
-@Repository
 public interface BannerRepository extends DatastoreRepository<BannerModel, String> {
 }

--- a/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.onsdigital.banner.repository;
 
-import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
+import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.BannerModel;
 
 public interface BannerRepository extends DatastoreRepository<BannerModel, String> {

--- a/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/BannerRepository.java
@@ -1,7 +1,10 @@
 package uk.gov.onsdigital.banner.repository;
 
+import org.springframework.stereotype.Repository;
+
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.BannerModel;
 
+@Repository
 public interface BannerRepository extends DatastoreRepository<BannerModel, String> {
 }

--- a/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
@@ -1,10 +1,7 @@
 package uk.gov.onsdigital.banner.repository;
 
-import org.springframework.stereotype.Repository;
-
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.TemplateModel;
 
-@Repository
 public interface TemplateRepository extends DatastoreRepository<TemplateModel, Long> {
 }

--- a/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
@@ -1,7 +1,10 @@
 package uk.gov.onsdigital.banner.repository;
 
+import org.springframework.stereotype.Repository;
+
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.TemplateModel;
 
+@Repository
 public interface TemplateRepository extends DatastoreRepository<TemplateModel, Long> {
 }

--- a/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
+++ b/src/main/java/uk/gov/onsdigital/banner/repository/TemplateRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.onsdigital.banner.repository;
 
-import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
+import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import uk.gov.onsdigital.banner.model.TemplateModel;
 
 public interface TemplateRepository extends DatastoreRepository<TemplateModel, Long> {

--- a/src/main/java/uk/gov/onsdigital/banner/service/BannerService.java
+++ b/src/main/java/uk/gov/onsdigital/banner/service/BannerService.java
@@ -7,13 +7,11 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 import uk.gov.onsdigital.banner.model.BannerModel;
 import uk.gov.onsdigital.banner.repository.BannerRepository;
 
 @Service
-@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.repository" })
 public class BannerService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BannerService.class);

--- a/src/main/java/uk/gov/onsdigital/banner/service/BannerService.java
+++ b/src/main/java/uk/gov/onsdigital/banner/service/BannerService.java
@@ -7,15 +7,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 import uk.gov.onsdigital.banner.model.BannerModel;
 import uk.gov.onsdigital.banner.repository.BannerRepository;
 
 @Service
+@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.repository" })
 public class BannerService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BannerService.class);
-  
+
   @Autowired
   private BannerRepository bannerRepo;
 
@@ -24,7 +26,7 @@ public class BannerService {
     Optional<BannerModel> banner = bannerRepo.findById(id);
     if (banner.isPresent()) {
       LOGGER.info("Banner retrieved",
-              kv("banner", banner));
+          kv("banner", banner));
     }
     return banner.orElseThrow();
   }
@@ -36,10 +38,10 @@ public class BannerService {
   }
 
   public void removeBanner(String bannerId) {
-    LOGGER.info("Removing banner", 
-      kv("id", bannerId));
+    LOGGER.info("Removing banner",
+        kv("id", bannerId));
     bannerRepo.deleteById(bannerId);
-    LOGGER.info("banner removed", 
-      kv("id", bannerId));
+    LOGGER.info("banner removed",
+        kv("id", bannerId));
   }
 }

--- a/src/main/java/uk/gov/onsdigital/banner/service/TemplateService.java
+++ b/src/main/java/uk/gov/onsdigital/banner/service/TemplateService.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 import uk.gov.onsdigital.banner.model.TemplateModel;
 import uk.gov.onsdigital.banner.repository.TemplateRepository;
@@ -16,10 +17,11 @@ import java.util.Optional;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 @Service
+@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.repository" })
 public class TemplateService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateService.class);
-  
+
   @Autowired
   private TemplateRepository templateRepo;
 
@@ -41,17 +43,17 @@ public class TemplateService {
 
     try {
       TemplateModel templateToSave = templateRepo.findById(template.getId())
-        .map(b -> {
-          LOGGER.info("Updating template", kv("oldtemplate", b),
-                  kv("newTitle", template.getTitle()),
-                  kv("newContent", template.getContent()));
-          b.setContent(template.getContent());
-          b.setTitle(template.getTitle());
-          return b;
-        }).orElseThrow();
+          .map(b -> {
+            LOGGER.info("Updating template", kv("oldtemplate", b),
+                kv("newTitle", template.getTitle()),
+                kv("newContent", template.getContent()));
+            b.setContent(template.getContent());
+            b.setTitle(template.getTitle());
+            return b;
+          }).orElseThrow();
       if (templateToSave.equals(template)) {
         LOGGER.info("No changes detected, template will not be updated",
-                kv("template", template));
+            kv("template", template));
         return template;
       }
       LOGGER.info("Saving updated template to database", kv("template", template));
@@ -65,10 +67,10 @@ public class TemplateService {
   public void removeTemplate(String templateId) {
     Long longId = Long.valueOf(templateId);
     LOGGER.info("Removing template",
-      kv("id", templateId));
+        kv("id", templateId));
     templateRepo.deleteById(longId);
     LOGGER.info("template removed",
-      kv("id", templateId));
+        kv("id", templateId));
   }
 
   public List<TemplateModel> getAllTemplates() {

--- a/src/main/java/uk/gov/onsdigital/banner/service/TemplateService.java
+++ b/src/main/java/uk/gov/onsdigital/banner/service/TemplateService.java
@@ -4,7 +4,6 @@ import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 import uk.gov.onsdigital.banner.model.TemplateModel;
 import uk.gov.onsdigital.banner.repository.TemplateRepository;
@@ -17,7 +16,6 @@ import java.util.Optional;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 @Service
-@ComponentScan(basePackages = { "uk.gov.onsdigital.banner.repository" })
 public class TemplateService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateService.class);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,15 +9,7 @@
         <thread>[ignore]</thread>
         <levelValue>[ignore]</levelValue>
       </fieldNames>
-<!--      <providers>-->
-<!--        <globalCustomFields>-->
-<!--          <customFields>{"service":"banner-api"}</customFields>-->
-<!--        </globalCustomFields>-->
-<!--        <logLevel>-->
-<!--          <fieldName>level</fieldName>-->
-<!--          <fieldName>severity</fieldName>-->
-<!--        </logLevel>-->
-<!--      </providers>-->
+      <customFields>{"service":"banner-api"}</customFields>
     </encoder>
   </appender>
   <root level="INFO">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,15 +9,15 @@
         <thread>[ignore]</thread>
         <levelValue>[ignore]</levelValue>
       </fieldNames>
-      <providers>
-        <globalCustomFields>
-          <customFields>{"service":"banner-api"}</customFields>
-        </globalCustomFields>
-        <logLevel>
-          <fieldName>level</fieldName>
-          <fieldName>severity</fieldName>
-        </logLevel>
-      </providers>
+<!--      <providers>-->
+<!--        <globalCustomFields>-->
+<!--          <customFields>{"service":"banner-api"}</customFields>-->
+<!--        </globalCustomFields>-->
+<!--        <logLevel>-->
+<!--          <fieldName>level</fieldName>-->
+<!--          <fieldName>severity</fieldName>-->
+<!--        </logLevel>-->
+<!--      </providers>-->
     </encoder>
   </appender>
   <root level="INFO">

--- a/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerIT.java
+++ b/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerIT.java
@@ -1,12 +1,7 @@
 package uk.gov.onsdigital.banner.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import java.net.URI;
-import java.util.List;
-import java.util.Optional;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.onsdigital.banner.DatastoreEmulator;
 import uk.gov.onsdigital.banner.model.BannerModel;
-import uk.gov.onsdigital.banner.model.TemplateModel;
 import uk.gov.onsdigital.banner.service.BannerService;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -51,24 +45,24 @@ public class BannerControllerIT {
   public void willReturnASingleBannerObject() {
     BannerModel expectedBanner = BannerModel.builder().build();
     Mockito.when(bannerService.getBanner("active"))
-      .thenReturn(expectedBanner);
+        .thenReturn(expectedBanner);
     BannerModel actualBanner = this.restTemplate.getForObject("http://localhost:" + port + "/banner",
-      BannerModel.class);
-    
+        BannerModel.class);
+
     assertEquals(expectedBanner, actualBanner);
   }
 
   @Test
   public void willCreateBanner() {
     BannerModel postedBanner = BannerModel.builder()
-      .content("Banner Content")
-      .build();
+        .content("Banner Content")
+        .build();
 
     Mockito.when(bannerService.createBanner(ArgumentMatchers.any()))
-      .thenReturn(postedBanner);
+        .thenReturn(postedBanner);
     ResponseEntity<BannerModel> resp = this.restTemplate.postForEntity("http://localhost:" + port + "/banner",
-      postedBanner, BannerModel.class);
-    
+        postedBanner, BannerModel.class);
+
     assertEquals(HttpStatus.CREATED, resp.getStatusCode());
     assertEquals(postedBanner, resp.getBody());
   }
@@ -76,7 +70,7 @@ public class BannerControllerIT {
   @Test
   public void willRemoveBanner() {
     this.restTemplate.delete(URI.create("http://localhost:" + port + "/banner"));
-    
+
     Mockito.verify(bannerService).removeBanner("active");
   }
 }

--- a/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerIT.java
+++ b/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerIT.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.onsdigital.banner.DatastoreEmulator;

--- a/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerUnitTest.java
+++ b/src/test/java/uk/gov/onsdigital/banner/controller/BannerControllerUnitTest.java
@@ -2,10 +2,7 @@ package uk.gov.onsdigital.banner.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,14 +11,12 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.onsdigital.banner.controller.BannerController;
 import uk.gov.onsdigital.banner.model.BannerModel;
-import uk.gov.onsdigital.banner.model.TemplateModel;
 import uk.gov.onsdigital.banner.service.BannerService;
 
 @ExtendWith(MockitoExtension.class)
 public class BannerControllerUnitTest {
-  
+
   @InjectMocks
   private BannerController bannerController;
 
@@ -37,7 +32,7 @@ public class BannerControllerUnitTest {
   @Test
   public void willReturn404IfNoBannerFound() {
     Mockito.when(bannerService.getBanner("active"))
-            .thenThrow(new NoSuchElementException());
+        .thenThrow(new NoSuchElementException());
     ResponseEntity<BannerModel> resp = bannerController.getBanner();
 
     assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());

--- a/src/test/java/uk/gov/onsdigital/banner/controller/TemplateControllerIT.java
+++ b/src/test/java/uk/gov/onsdigital/banner/controller/TemplateControllerIT.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.onsdigital.banner.DatastoreEmulator;
@@ -36,21 +36,21 @@ public class TemplateControllerIT {
   }
 
   @LocalServerPort
-	private int port;
+  private int port;
 
-	@Autowired
+  @Autowired
   private TestRestTemplate restTemplate;
 
   @MockBean
   private TemplateService templateService;
-  
+
   @Test
   public void willReturnBannersObject() {
     Mockito.when(templateService.getAllTemplates())
-      .thenReturn(List.of(TemplateModel.builder().build()));
+        .thenReturn(List.of(TemplateModel.builder().build()));
     List<TemplateModel> banners = this.restTemplate.getForObject("http://localhost:" + port + "/template",
         List.class);
-    
+
     assertEquals(1, banners.size());
   }
 
@@ -58,25 +58,25 @@ public class TemplateControllerIT {
   public void willReturnASingleBannerObject() {
     TemplateModel expectedBanner = TemplateModel.builder().build();
     Mockito.when(templateService.getTemplate("1"))
-      .thenReturn(expectedBanner);
+        .thenReturn(expectedBanner);
     TemplateModel actualBanner = this.restTemplate.getForObject("http://localhost:" + port + "/template/1",
-      TemplateModel.class);
-    
+        TemplateModel.class);
+
     assertEquals(expectedBanner, actualBanner);
   }
 
   @Test
   public void willCreateBanner() {
     TemplateModel postedBanner = TemplateModel.builder()
-      .title("BannerTitle")
-      .content("Banner Content")
-      .build();
+        .title("BannerTitle")
+        .content("Banner Content")
+        .build();
 
     Mockito.when(templateService.createTemplate(ArgumentMatchers.any()))
-      .thenReturn(postedBanner);
+        .thenReturn(postedBanner);
     ResponseEntity<TemplateModel> resp = this.restTemplate.postForEntity("http://localhost:" + port + "/template",
-      postedBanner, TemplateModel.class);
-    
+        postedBanner, TemplateModel.class);
+
     assertEquals(HttpStatus.CREATED, resp.getStatusCode());
     assertEquals(postedBanner, resp.getBody());
   }
@@ -84,7 +84,7 @@ public class TemplateControllerIT {
   @Test
   public void willRemoveBanner() {
     this.restTemplate.delete(URI.create("http://localhost:" + port + "/template/1"));
-    
+
     Mockito.verify(templateService).removeTemplate("1");
   }
 }

--- a/src/test/java/uk/gov/onsdigital/banner/controller/TemplateControllerUnitTest.java
+++ b/src/test/java/uk/gov/onsdigital/banner/controller/TemplateControllerUnitTest.java
@@ -9,18 +9,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.onsdigital.banner.model.TemplateModel;
-import uk.gov.onsdigital.banner.service.BannerService;
 import uk.gov.onsdigital.banner.service.TemplateService;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 public class TemplateControllerUnitTest {
-  
+
   @InjectMocks
   private TemplateController templateController;
 
@@ -44,7 +41,7 @@ public class TemplateControllerUnitTest {
   @Test
   public void willReturnTemplatesIfData() {
     ResponseEntity<List<TemplateModel>> resp = templateController.getTemplates();
-    
+
     assertEquals(HttpStatus.OK, resp.getStatusCode());
   }
 
@@ -58,7 +55,7 @@ public class TemplateControllerUnitTest {
   @Test
   public void willReturn404IfNoTemplateFound() {
     Mockito.when(templateService.getTemplate("1"))
-      .thenThrow(new NoSuchElementException());
+        .thenThrow(new NoSuchElementException());
     ResponseEntity<TemplateModel> resp = templateController.getTemplate("1");
 
     assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
@@ -67,7 +64,7 @@ public class TemplateControllerUnitTest {
   @Test
   public void willReturnBadRequestIfPathVariableIsNotNumber() {
     Mockito.when(templateService.getTemplate("abc"))
-      .thenThrow(new NumberFormatException());
+        .thenThrow(new NumberFormatException());
     ResponseEntity<TemplateModel> resp = templateController.getTemplate("abc");
 
     assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
@@ -90,8 +87,8 @@ public class TemplateControllerUnitTest {
   @Test
   public void willReturnBadRequestIfPathVariableIsNotNumberOnDelete() {
     Mockito.doThrow(new NumberFormatException())
-      .when(templateService)
-      .removeTemplate("abc");
+        .when(templateService)
+        .removeTemplate("abc");
     ResponseEntity<TemplateModel> resp = templateController.removeTemplate("abc");
 
     assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
@@ -101,7 +98,7 @@ public class TemplateControllerUnitTest {
   public void willUpdateBanner() {
     TemplateModel newBanner = TemplateModel.builder().title("1").id(1L).build();
     Mockito.when(templateService.updateTemplate(newBanner))
-      .thenReturn(newBanner);
+        .thenReturn(newBanner);
 
     ResponseEntity<TemplateModel> resp = templateController.updateTemplate(newBanner);
 
@@ -111,7 +108,7 @@ public class TemplateControllerUnitTest {
   @Test
   public void willReturn400IfNullBannerSuppliedForUpdate() {
     Mockito.when(templateService.updateTemplate(null))
-      .thenThrow(new IllegalArgumentException());
+        .thenThrow(new IllegalArgumentException());
     ResponseEntity<TemplateModel> resp = templateController.updateTemplate(null);
 
     assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());

--- a/src/test/java/uk/gov/onsdigital/banner/service/BannerServiceUnitTest.java
+++ b/src/test/java/uk/gov/onsdigital/banner/service/BannerServiceUnitTest.java
@@ -7,11 +7,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.onsdigital.banner.model.BannerModel;
-import uk.gov.onsdigital.banner.model.TemplateModel;
 import uk.gov.onsdigital.banner.repository.BannerRepository;
-import uk.gov.onsdigital.banner.repository.TemplateRepository;
-
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -20,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class BannerServiceUnitTest {
-  
+
   @InjectMocks
   private BannerService bannerService;
 
@@ -31,7 +27,7 @@ public class BannerServiceUnitTest {
   public void willReturnSingleBanner() {
     BannerModel expected1 = BannerModel.builder().content("content text").build();
     Mockito.when(bannerRepo.findById("active"))
-      .thenReturn(Optional.of(expected1));
+        .thenReturn(Optional.of(expected1));
 
     BannerModel banner = bannerService.getBanner("active");
 
@@ -41,7 +37,7 @@ public class BannerServiceUnitTest {
   @Test
   public void willThrowIfNoBannerPresent() {
     Mockito.when(bannerRepo.findById("active"))
-      .thenReturn(Optional.empty());
+        .thenReturn(Optional.empty());
 
     assertThrows(NoSuchElementException.class, () -> bannerService.getBanner("active"));
   }

--- a/src/test/java/uk/gov/onsdigital/banner/service/TemplateServiceUnitTest.java
+++ b/src/test/java/uk/gov/onsdigital/banner/service/TemplateServiceUnitTest.java
@@ -2,8 +2,6 @@ package uk.gov.onsdigital.banner.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.never;
-
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -19,7 +17,7 @@ import uk.gov.onsdigital.banner.repository.TemplateRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class TemplateServiceUnitTest {
-  
+
   @InjectMocks
   private TemplateService templateService;
 
@@ -30,7 +28,7 @@ public class TemplateServiceUnitTest {
   public void willReturnBannerIfNoChangesToUpdate() {
     TemplateModel expected = TemplateModel.builder().title("1").id(1L).build();
     Mockito.when(templateRepo.findById(1L))
-      .thenReturn(Optional.of(expected));
+        .thenReturn(Optional.of(expected));
     TemplateModel actual = templateService.updateTemplate(expected);
 
     assertEquals(expected, actual);
@@ -38,7 +36,7 @@ public class TemplateServiceUnitTest {
 
   @Test
   public void willThrowExcetptionIfNullBannerIdSuppliedForUpdate() {
-    assertThrows(IllegalArgumentException.class, () ->  templateService.updateTemplate(null));
+    assertThrows(IllegalArgumentException.class, () -> templateService.updateTemplate(null));
   }
 
   @Test
@@ -47,9 +45,9 @@ public class TemplateServiceUnitTest {
     TemplateModel expected2 = TemplateModel.builder().title("2").build();
 
     Mockito.when(templateRepo.findAll())
-      .thenReturn(List.of(expected1, expected2));
+        .thenReturn(List.of(expected1, expected2));
     List<TemplateModel> banners = templateService.getAllTemplates();
-    
+
     assertEquals(2, banners.size());
     assertEquals(expected1, banners.get(0));
     assertEquals(expected2, banners.get(1));
@@ -59,7 +57,7 @@ public class TemplateServiceUnitTest {
   public void willReturnSingleBanner() {
     TemplateModel expected1 = TemplateModel.builder().title("1").build();
     Mockito.when(templateRepo.findById(Long.valueOf("1")))
-      .thenReturn(Optional.of(expected1));
+        .thenReturn(Optional.of(expected1));
 
     TemplateModel banner = templateService.getTemplate("1");
 
@@ -69,7 +67,7 @@ public class TemplateServiceUnitTest {
   @Test
   public void willThrowIfNoBannerPresent() {
     Mockito.when(templateRepo.findById(Long.valueOf("1")))
-      .thenReturn(Optional.empty());
+        .thenReturn(Optional.empty());
 
     assertThrows(NoSuchElementException.class, () -> templateService.getTemplate("1"));
   }


### PR DESCRIPTION
# What and why?
There was a security advisory on the GCP Spring Datastore starter. This has been disowned by Spring and taken up by Google themselves in the last couple of years, so this PR updates to reflect that

# How to test?
Smoke test banners

# Trello
RAS-314