### PR TITLE
Migrate Banner service from deprecated openJDK docker image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 # How to test?
 
-# Trello
+# Jira

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jre-alpine
 
 RUN addgroup --system banner-group && adduser --system banner-user --ingroup banner-group
 

--- a/_infra/helm/banner-api/Chart.yaml
+++ b/_infra/helm/banner-api/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 2.0.7
+version: 2.0.8
 
-appVersion: 2.0.7
+appVersion: 2.0.8


### PR DESCRIPTION
# What and why?
There is a requirement to migrate from the deprecated version of openJDK-17 to eclipse. This PR achieves this.

# How to test?
Run unit and acceptance tests in UI.

# Jira
https://jira.ons.gov.uk/browse/RAS-971